### PR TITLE
Add create create: yes to lineinfile

### DIFF
--- a/kubernetes-setup/master-playbook.yml
+++ b/kubernetes-setup/master-playbook.yml
@@ -78,10 +78,11 @@
         - kubeadm 
         - kubectl
 
-  #- name: Configure node ip
-  #  lineinfile:
-  ##    path: /etc/default/kubelet
- #      line: KUBELET_EXTRA_ARGS=--node-ip={{ node_ip }}
+  - name: Configure node ip
+    lineinfile:
+      path: /etc/default/kubelet
+      line: KUBELET_EXTRA_ARGS=--node-ip={{ node_ip }}
+      create: yes
 
   - name: Restart kubelet
     service:

--- a/kubernetes-setup/node-playbook.yml
+++ b/kubernetes-setup/node-playbook.yml
@@ -78,6 +78,12 @@
         - kubeadm 
         - kubectl
 
+  - name: Configure node ip
+    lineinfile:
+      path: /etc/default/kubelet
+      line: KUBELET_EXTRA_ARGS=--node-ip={{ node_ip }}
+      create: yes
+
   - name: Restart kubelet
     service:
       name: kubelet


### PR DESCRIPTION
Restored lineinfile task to playbooks.

Added create: yes parameter to create the /etc/default/kubelet file if it didn't exist, which was why the lineinfile was failing in the first place.  